### PR TITLE
deployfish-ext: add command to wait until service is stable

### DIFF
--- a/src/deployfish-ext/deployfish_ext/cli.py
+++ b/src/deployfish-ext/deployfish_ext/cli.py
@@ -70,3 +70,19 @@ def service_exists(ctx, service_name):
     else:
         LoggingHelper.print_info_n_exit(
             "service {} is not exists.".format(service_name), 1)
+
+@ext.command(
+    'service_stable', short_help="Wait until ecs service is stable.")
+@click.pass_context
+@click.argument('service_name')
+def service_stable(ctx, service_name):
+    """
+    Wait until ecs service SERVICE_NAME is stable.
+    """
+    ConfigHelper.init(ctx)
+    if Service(service_name, config=ConfigHelper.get_config()).wait_until_stable():
+        LoggingHelper.print_info_n_exit(
+            "service {} is stable.".format(service_name), 0)
+    else:
+        LoggingHelper.print_info_n_exit(
+            "service {} is not stable.".format(service_name), 1)


### PR DESCRIPTION
### Purpose

To deploy multiple services at one time and then check the services' status one by one

### Output

```
Attaching to command-n-conquer_deployfish_1
deployfish_1  | Using '/yml/Backend/FundOldDriver/deployfish.int.yml' as our deployfish config file
deployfish_1  | Deployment Desired Pending Running
deployfish_1  | PRIMARY 1 0 1
deployfish_1  |
deployfish_1  | Service:
deployfish_1  | (service be-int-api) has reached a steady state.
deployfish_1  | (service be-int-api) has stopped 1 running tasks: (task 4ebcadc7-469b-4111-94ec-c323505ca1c4).
deployfish_1  | (service be-int-api) has begun draining connections on 1 tasks.
deployfish_1  | (service be-int-api) deregistered 1 targets in (target-group arn:aws:elasticloadbalancing:ap-northeast-1)
deployfish_1  | (service be-int-api) registered 1 targets in (target-group arn:aws:elasticloadbalancing:ap-northeast-1)
deployfish_1  | (service be-int-api) has started 1 tasks: (task bef25072-dd0e-47b5-9187-7fa40b8b3975).
deployfish_1  |
deployfish_1  | Load Balancer
deployfish_1  | i-0efe43ea441dab802 healthy
deployfish_1  |
deployfish_1  | Deployment successful.
deployfish_1  |
deployfish_1  | Service Be-Int-Api Is Stable.
command-n-conquer_deployfish_1 exited with code 0
```