### PR TITLE
change to use boto3 api to check existence of ecs service.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 builds/reports
 dist/
+.vscode/

--- a/src/deployfish-ext/.gitignore
+++ b/src/deployfish-ext/.gitignore
@@ -2,4 +2,5 @@
 *.egg-info
 dist/
 build/
+.venv/
 deployfish.yml

--- a/src/deployfish-ext/Makefile
+++ b/src/deployfish-ext/Makefile
@@ -1,7 +1,9 @@
 RAWVERSION = $(filter-out __version__ = , $(shell grep __version__ deployfish_ext/__init__.py))
 VERSION = $(strip $(shell echo $(RAWVERSION)))
-
 PACKAGE = deployfish
+VENV_ENV_PY27 := $(PACKAGE)-py27
+VENV_DIR_PY27 := .venv/$(VENV_ENV_PY27)
+LOG_DIR := .venv/install.log
 
 clean:
 	rm -rf *.tar.gz dist *.egg-info *.rpm
@@ -13,3 +15,17 @@ version:
 dist: clean
 	@python setup.py sdist
 	@python setup.py bdist_wheel --universal
+
+
+mkvenv-py27:
+ifeq "$(wildcard $(VENV_DIR_PY27))" ""
+	@mkdir -p $(VENV_DIR_PY27)
+	@virtualenv --python=python2.7 $(VENV_DIR_PY27) > $(LOG_DIR) 2>&1
+	@( \
+		. $(VENV_DIR_PY27)/bin/activate; \
+		pip install -Ur ./requirements.txt >> $(LOG_DIR) 2>&1; \
+		pip install -U pylint; \
+		pip install -e ./ >> $(LOG_DIR) 2>&1; \
+	)
+endif
+	@echo ". $(VENV_DIR_PY27)/bin/activate"

--- a/src/deployfish-ext/deployfish_ext/aws/ecs.py
+++ b/src/deployfish-ext/deployfish_ext/aws/ecs.py
@@ -34,3 +34,19 @@ class EcsHelper(object):
                     "Can not find ecs cluster {}".format(cluster_name))
 
         return response['clusters'][0]['clusterArn']
+
+    @staticmethod
+    def service_exists(cluster_name, service_name):
+        EcsHelper.__init()
+        response = EcsHelper.__client.describe_services(
+            cluster=cluster_name,
+            services=[service_name])
+
+        if 'failures' in response and len(response['failures']) >= 1:
+            if response['failures'][0]['reason'] == 'MISSING':
+                return False
+            else:
+                raise RuntimeError(
+                    "unknown error happend - response :\n{}".format(response))
+
+        return True

--- a/src/deployfish-ext/deployfish_ext/cli.py
+++ b/src/deployfish-ext/deployfish_ext/cli.py
@@ -2,6 +2,7 @@ from deployfish.cli import cli
 from deployfish.aws.ecs import Service
 from deployfish_ext.core import BatchTask, CrontabJobs, LoggingHelper
 from deployfish_ext.config import ConfigHelper
+from deployfish_ext.aws.ecs import EcsHelper
 
 import click
 
@@ -64,7 +65,8 @@ def service_exists(ctx, service_name):
     Check ecs service with SERVICE_NAME is already exists.
     """
     ConfigHelper.init(ctx)
-    if Service(service_name, config=ConfigHelper.get_config()).exists():
+    cluster_name = ConfigHelper.get_cluster_name(service_name)
+    if EcsHelper.service_exists(cluster_name, service_name):
         LoggingHelper.print_info_n_exit(
             "service {} is already exists.".format(service_name), 0)
     else:

--- a/src/deployfish-ext/requirements.txt
+++ b/src/deployfish-ext/requirements.txt
@@ -1,0 +1,4 @@
+click>=6.7
+deployfish>=0.24.0
+boto3>=1.7.55
+botocore>=1.10.55


### PR DESCRIPTION
original way which use deployfish core function will cause this error situation
```
+ deploy -f Backend/FundOldDriver/API/deployfish.int.yml -i ext service_exists be-int-api
Using 'Backend/FundOldDriver/API/deployfish.int.yml' as our deployfish config file
Traceback (most recent call last):
  File "/usr/bin/deploy", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/site-packages/deployfish/dplycli.py", line 686, in main
    cli(obj={})
  File "/usr/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/deployfish_ext/cli.py", line 67, in service_exists
    if Service(service_name, config=ConfigHelper.get_config()).exists():
  File "/usr/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 804, in __init__
    self.from_aws()
  File "/usr/lib/python2.7/site-packages/deployfish/aws/ecs.py", line 1338, in from_aws
    t.from_aws(helpers[t.family])
KeyError: 'be-int-task'```

Because deployfish think be-int-task task helper already exists, which yes in the original execute flow, but no in our own execute flow

So use boto3 api to check existence of ecs service instead.