### PR TITLE
add gcloud and kubectl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 builds/reports
 dist/
 .vscode/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,3 +35,5 @@ ENTRYPOINT []
 COPY --from=build-stage /srv/app/dist /tmp/dist/
 
 RUN sh /tmp/dist/tools-install/install.sh
+
+ENV PATH=${PATH}:/google-cloud-sdk/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,5 @@ COPY --from=build-stage /srv/app/dist /tmp/dist/
 RUN sh /tmp/dist/tools-install/install.sh
 
 ENV PATH=${PATH}:/google-cloud-sdk/bin
+
+COPY ./src/scripts /scripts

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Cnyes Mozi-Boxes is a docker image, that provides a helper command collections t
 * git
 * test-kitchen
 * inspec
+* gcloud
+* kubectl
 
 ## Bitbucket cli
 

--- a/src/scripts/gcloud-auth.sh
+++ b/src/scripts/gcloud-auth.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud auth activate-service-account --key-file=/credential/credentials.json || exit 1

--- a/src/scripts/gcloud-gke-auth.sh
+++ b/src/scripts/gcloud-gke-auth.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud container clusters get-credentials ${CLUSTER_NAME} --zone ${GKE_ZONE} --project ${GKE_PROJECT} || exit 1

--- a/src/scripts/log-operator.sh
+++ b/src/scripts/log-operator.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+TODAY=$(date +%Y%m%d)
+
+if [[ -z ${INCLUDE_TODAY} ]]; then
+  SEARCH=($(ls -A ${SEARCH_TARGET} | grep -v ${TODAY}))
+else
+  SEARCH=($(ls -A ${SEARCH_TARGET}))
+fi
+
+for log in "${SEARCH[@]}"; do
+  echo "Copy ${log} to ${UPLOAD_URL}/${log##*/}"
+
+  if [[ -z ${UPLOAD_TO_GCS} ]]; then
+    echo "Ignore ${log} to upload to gcs"
+  else
+    gsutil cp ${log} ${UPLOAD_URL}/${log##*/} || exit 0
+    echo "Upload ${log} to ${UPLOAD_URL}/${log##*/} Success..."
+  fi
+
+  if [[ -z ${REQUIRE_DELETE} ]]; then
+    echo "Ignore removing ${log}"
+  else
+    rm ${log} || exit 1
+    echo "${log} deleted"
+  fi
+done
+
+echo "Done..."

--- a/src/tools-install/install.sh
+++ b/src/tools-install/install.sh
@@ -38,5 +38,14 @@ git clone https://github.com/caltechads/batchbeagle.git
 cd batchbeagle || exit 1
 python setup.py install
 
+# install gcloud & kubectl
+cd /
+wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-218.0.0-linux-x86_64.tar.gz
+tar -xzvf google-cloud-sdk-218.0.0-linux-x86_64.tar.gz
+rm google-cloud-sdk-218.0.0-linux-x86_64.tar.gz
+
+/google-cloud-sdk/bin/gcloud components update --quiet
+/google-cloud-sdk/bin/gcloud components install kubectl --quiet
+
 # cleanup
 rm -rf /tmp/dist /tmp/batchbeagle


### PR DESCRIPTION
1. install gcloud and kubectl to interact with GCP & GKE
2. add helper scripts 
    * gcloud-auth.sh: refer credentials.json under /credential
    * gcloud-gke-auth.sh: get credentials from GKE
        * rerfer env: CLUSTER_NAME, GKE_ZONE and GKE_PROJECT
    * log-operator.sh: tool for copying log to GCS