### PR TITLE
create jenkins user for running glcoud

### DIFF
--- a/src/tools-install/install.sh
+++ b/src/tools-install/install.sh
@@ -47,5 +47,8 @@ rm google-cloud-sdk-218.0.0-linux-x86_64.tar.gz
 /google-cloud-sdk/bin/gcloud components update --quiet
 /google-cloud-sdk/bin/gcloud components install kubectl --quiet
 
+mkdir /.config
+chmod 777 /.config
+
 # cleanup
 rm -rf /tmp/dist /tmp/batchbeagle

--- a/src/tools-install/install.sh
+++ b/src/tools-install/install.sh
@@ -47,8 +47,7 @@ rm google-cloud-sdk-218.0.0-linux-x86_64.tar.gz
 /google-cloud-sdk/bin/gcloud components update --quiet
 /google-cloud-sdk/bin/gcloud components install kubectl --quiet
 
-mkdir /.config
-chmod 777 /.config
+adduser -D jenkins
 
 # cleanup
 rm -rf /tmp/dist /tmp/batchbeagle


### PR DESCRIPTION
create jenkins user for running gcloud
without jenkins user, gcloud will try to create directory under /.config for logging and the directory is prohibited to access. 
with jenkins user, gcloud will create directory under ~/.config